### PR TITLE
 Return the player object onReady (#33)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class Plyr extends Component {
 
     if (this.player) {
       this.player.on('ready', () => {
-        this.props.onReady && this.props.onReady();
+        this.props.onReady && this.props.onReady(this.player);
       });
 
       this.player.on('play', () => {


### PR DESCRIPTION
* Return the player object onReady

I think it's an easy and also expected behaviour to return the player object in the onReady callback so users can access the API

* Revert "Return the player object onReady"

I think it's an expected behaviour to return the player object on the onReady callback - allows for easy access to the player's API